### PR TITLE
Scryfall headers, Modal Dual Izzet, and Scalding Tarn

### DIFF
--- a/config/card-tags.toml
+++ b/config/card-tags.toml
@@ -1901,6 +1901,7 @@
 "Savai Triome" = ["Mardu Mana", "Tapland", "ETB Tapped", "Cycling", "Tricolor Cycling Land", "Draw"]
 "Savannah" = ["True Dual", "Selesnya Mana"]
 "Scabland" = ["ETB Tapped", "Tapland", "Slow Pain Land", "Colorless Mana", "Boros Mana", "Pain Land"]
+"Scalding Tarn" = ["Manaless Land", "Fetch", "Fast Fetch", "Sac Land"]
 "Scaled Herbalist" = ["Ramp"]
 "Scaled Nurturer" = ["Dork", "Ramp", "Green Mana"]
 "Scale the Heights" = ["Draw", "Ramp"]

--- a/config/card-tags.toml
+++ b/config/card-tags.toml
@@ -1810,7 +1810,7 @@
 "Rivendell" = ["Blue Mana", "Utility Land", "Scry", "Middle Earth Landmark"]
 "Riven Turnbull" = ["Dork", "Ramp", "Black Mana"]
 "River Delta" = ["Depletion Dual", "Dimir Mana", "Depletion Land"]
-"Riverglide Pathway // Lavaglide Pathway" = ["Blue Mana", "Red Mana"]
+"Riverglide Pathway // Lavaglide Pathway" = ["Modal", "Modal Dual", "Blue Mana", "Red Mana"]
 "River Herald Guide" = ["Dig"]
 "River Herald Scout" = ["Dig"]
 "River of Tears" = ["Futuresight Dual", "Dimir Mana"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,11 @@ async fn main() -> anyhow::Result<()> {
         bulk_data = std::fs::read_to_string(path)?;
         data_updated = std::fs::metadata(path)?.modified()?.into();
     } else {
-        let bulk_data_info = reqwest::get(BULK_DATA_API_URL)
+        let bulk_data_info = reqwest::Client::new()
+            .get(BULK_DATA_API_URL)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::USER_AGENT, "manabase (https://github.com/VoidStarKat/manabase)")
+            .send()
             .await?
             .json::<BulkDataInfo>()
             .await?;


### PR DESCRIPTION
- send Accept and User-Agent headers to Scryfall ([required](https://scryfall.com/blog/user-agent-and-accept-header-now-required-on-the-api-225) as of 2024-08-08).
- add Modal Dual tags to Riverglide Pathway // Lavaglide Pathway (#9).
- add Scalding Tarn (#10).
